### PR TITLE
Add extrema loss function

### DIFF
--- a/AAnet_torch/models/AAnet_base.py
+++ b/AAnet_torch/models/AAnet_base.py
@@ -79,3 +79,10 @@ class BaseAAnet(nn.Module):
         '''
         X_bary = self.euclidean_to_barycentric(archetypal_embedding)
         return torch.mean(self.dist_to_simplex(X_bary) ** 2)
+    
+    def calc_diffusion_extrema_loss(self, archetypal_embedding):
+        '''
+        Returns MSE diffusion extrema loss (minimize MSE between diffusion extrema (concatenated to batch as first n_archetypes samples) and archetypes)
+        '''
+        X_bary = self.euclidean_to_barycentric(archetypal_embedding)
+        return torch.mean((X_bary[:self.n_archetypes,:] - torch.eye(self.n_archetypes)) ** 2)


### PR DESCRIPTION
Add function that minimizes the MSE between diffusion extrema and the archetypes in the latent layer. This effectively initializes archetypes to diffusion extrema which improves stability and interpretability. AAnet does not learn the diffusion extrema when they are not useful initializations.