### PR TITLE
Added utility functions to sample from stereographic spherical simplices

### DIFF
--- a/AAnet_torch/utils.py
+++ b/AAnet_torch/utils.py
@@ -1,6 +1,94 @@
 import numpy as np
 import torch
 
+def _barycentric_to_euclidean(X_barycentric, simplex_radius):
+    '''
+    Converts an M x (N + 1) array of barycentric coordinates into an M x N array
+    of the corresponding Euclidean coordinates.
+    '''
+
+    n_dim = X_barycentric.shape[1] - 1
+    coord_transform = np.zeros((n_dim, n_dim + 1))
+
+    # Construct the N x (N + 1) coordinate transformation matrix
+    # See the 'Simplex' Wiki page for a detailed explanation
+    np.fill_diagonal(coord_transform, 1 / np.sqrt(2))
+    for i in range(n_dim):
+        for j in range(n_dim):
+            coord_transform[i, j] -= 1 / (n_dim * np.sqrt(2)) * (1 + 1 / np.sqrt(n_dim + 1))
+    for i in range(n_dim):
+        coord_transform[i, n_dim] = 1 / (2 * np.sqrt(n_dim + 1))
+
+    # Transform the simplex coordinates into points in R^n
+    X_euclidean = simplex_radius * coord_transform @ X_barycentric.T
+    X_euclidean = X_euclidean.T
+
+    return X_euclidean
+
+def _sample_from_n_simplex(n_dim, simplex_radius, n_samples):
+    '''
+    Samples Eucliean points uniformly from an N-dimensional simplex of a
+    specified radius.
+    '''
+
+    exp_samples = np.random.exponential(size=(n_dim, n_samples))
+    X_barycentric = exp_samples / np.linalg.norm(exp_samples, ord=1, axis=0)
+    X_barycentric = X_barycentric.T
+
+    X_euclidean = _barycentric_to_euclidean(X_barycentric, simplex_radius)
+
+    return X_euclidean
+
+def _stereographic_inverse(X_hyperplane):
+    '''
+    Computes the inverse of a stereographic projection, mapping points in N-dimensional
+    Euclidean space to points in (N + 1)-dimensional Euclidean space on the unit hypersphere.
+    '''
+
+    X_hyperplane = X_hyperplane.T
+    X_sphere = np.zeros((X_hyperplane.shape[0] + 1, X_hyperplane.shape[1]))
+
+    norms = np.linalg.norm(X_hyperplane, axis=0)
+    X_sphere[0] = (norms**2 - 1) / (norms**2 + 1)
+    for i in range(1, X_sphere.shape[0]):
+        X_sphere[i] = 2 * X_hyperplane[i - 1] / (norms**2 + 1)
+
+    return X_sphere.T
+
+def sample_from_stereo_sphere_simplex(n_dim=3, simplex_radius=1.0, n_samples=1000):
+    '''
+    Samples non-uniformly from an N-dimensional simplex projected onto an
+    N-dimensional sphere using a stereographic projection.
+    
+    (Note that a 'stereographic spherical simplex' is _not_ the same thing as a
+    spherical simplex defined using the submanifold geometry the N-dimensional sphere
+    inherets from (N + 1)-dimensional Euclidean space.)
+
+    Parameters
+    ----------
+    n_dim : int, optional, default: 3
+        dimension of the sphere the points are sampled from (note that the
+        sphere is a 2-dimensional space)
+
+    simplex_radius : float, optional, default: 1
+        radius of the simplex in Euclidean space, before it is projected onto
+        the sphere
+
+    n_samples : int, optional, default: 1000
+        number of points sampled from the spherical simplex
+
+    Returns
+    -------
+    A numpy array from shape (n_samples, n_dim + 1)
+    '''
+
+    X_hyperplane = _sample_from_n_simplex(n_dim + 1, simplex_radius, n_samples)
+    print(X_hyperplane.shape)
+    X_sphere = _stereographic_inverse(X_hyperplane)
+    print(X_sphere.shape)
+
+    return X_sphere
+
 def get_n_simplex(n=2, scale=1, device=None):
     '''
     Returns an n-simplex centered at the origin


### PR DESCRIPTION
Added functions to sample points non-uniformly from "stereographic spherical simplices", which are simplices that are projected onto the unit hypersphere using stereographic projection.  This sampling is uniform in the simplex _before_ it is projected onto the hypersphere.  Note that these simplices are _not_ the same thing as spherical simplices in the submanifold geometry that hyperspheres inherit from the ambient Euclidean space.